### PR TITLE
Add handler for message reactions - fixes #64

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"os"
 	"strings"
 	"time"
-	"math/rand"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/chrislgardner/go-discord-bot/hnydiscordgo"
@@ -37,6 +37,20 @@ func sendResponse(ctx context.Context, s *discordgo.Session, cid string, m strin
 	beeline.AddField(ctx, "chennel", cid)
 
 	s.ChannelMessageSend(cid, m)
+
+}
+
+func sendReply(ctx context.Context, s *discordgo.Session, m string, om *discordgo.MessageReference) {
+
+	ctx, span := beeline.StartSpan(ctx, "sendReply")
+	defer span.Send()
+
+	span.AddField("sendReply.response", m)
+	span.AddField("sendReply.originalMessage.id", om.MessageID)
+	span.AddField("sendReply.originalMessage.guildID", om.GuildID)
+	span.AddField("sendReply.originalMessage.channelID", om.ChannelID)
+
+	s.ChannelMessageSendReply(om.ChannelID, m, om)
 
 }
 
@@ -154,12 +168,12 @@ func quipMessages(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 }
 
-func featureRequestResponse(ctx context.Context, author string) (string) {
+func featureRequestResponse(ctx context.Context, author string) string {
 	ctx, span := beeline.StartSpan(ctx, "featureRequestResponse")
 	defer span.Send()
 
 	fqResponses := []string{"File your own damned issue <@%s>: https://github.com/ChrisLGardner/go-discord-bot/issues",
-							"Hey <@%s>, I'll keep an eye out for your PR: https://github.com/ChrisLGardner/go-discord-bot/pulls"}
+		"Hey <@%s>, I'll keep an eye out for your PR: https://github.com/ChrisLGardner/go-discord-bot/pulls"}
 	span.AddField("featureRequestResponse.possibleChoices", fqResponses)
 
 	fqResponse, randNum := chooseRandom(fqResponses)
@@ -170,13 +184,13 @@ func featureRequestResponse(ctx context.Context, author string) (string) {
 	return message
 }
 
-func languageResponse(ctx context.Context) (string) {
+func languageResponse(ctx context.Context) string {
 	ctx, span := beeline.StartSpan(ctx, "languageResponse")
 	defer span.Send()
 
 	languageGifs := []string{"https://tenor.com/view/captain-america-marvel-avengers-gif-18378867",
-							 "https://tenor.com/view/marvel-tony-stark-iron-man-gif-18079972",
-							 "https://tenor.com/view/captain-america-marvel-avengers-gif-14328153"}
+		"https://tenor.com/view/marvel-tony-stark-iron-man-gif-18079972",
+		"https://tenor.com/view/captain-america-marvel-avengers-gif-14328153"}
 	span.AddField("languageResponse.possibleChoices", languageGifs)
 
 	pickGif, randNum := chooseRandom(languageGifs)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/chrislgardner/go-discord-bot
 go 1.14
 
 require (
-	github.com/bwmarrin/discordgo v0.22.0
+	github.com/bwmarrin/discordgo v0.23.2
 	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/honeycombio/beeline-go v0.6.1
 	github.com/katnegermis/pocketmine-rcon v0.0.0-20171229130351-03454839a2aa

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/aws/aws-sdk-go v1.34.28 h1:sscPpn/Ns3i0F4HPEWAVcwdIRaZZCuL7llJ2/60yPI
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/benbjohnson/clock v1.0.3 h1:vkLuvpK4fmtSCuo60+yC63p7y0BmQ8gm5ZXGuBCJyXg=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
-github.com/bwmarrin/discordgo v0.22.0 h1:uBxY1HmlVCsW1IuaPjpCGT6A2DBwRn0nvOguQIxDdFM=
-github.com/bwmarrin/discordgo v0.22.0/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
+github.com/bwmarrin/discordgo v0.23.2 h1:BzrtTktixGHIu9Tt7dEE6diysEF9HWnXeHuoJEt2fH4=
+github.com/bwmarrin/discordgo v0.23.2/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -158,6 +158,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -222,6 +223,7 @@ github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
@@ -346,6 +348,7 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/twmb/murmur3 v1.0.0 h1:MLMwMEQRKsu94uJnoveYjjHmcLwI3HNcWXP4LJuNe3I=
 github.com/twmb/murmur3 v1.0.0/go.mod h1:5Y5m8Y8WIyucaICVP+Aep5C8ydggjEuRQHDq1icoOYo=

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 	session.Identify.Intents = discordgo.MakeIntent(discordgo.IntentsGuildMessages)
 
 	session.AddHandler(MessageRespond)
+	session.AddHandler(MessageReact)
 }
 
 func getFeatureFlagState(ctx context.Context, id string, roles []string, flag string) bool {


### PR DESCRIPTION
Updates the version of discordgo being used to include support for replying to messages. When responding to a reaction we assume it's going to be 1 or more messages back and therefore reply to it rather than just posting into the same channel, this gives some context to the response.